### PR TITLE
Add unit tests for App component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+export default {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "stylelint": "npx stylelint '**/*.scss'",
     "preview": "vite preview",
     "eslint:fix": "eslint --fix",
-    "stylelint:fix": "npx stylelint --fix '**/*.scss'"
+    "stylelint:fix": "npx stylelint --fix '**/*.scss'",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -36,6 +37,8 @@
     "stylelint-order": "^6.0.4",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.25.0",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import App from './App'
+
+test('renders Vite + React heading', () => {
+  render(<App />)
+  const headingElement = screen.getByText(/Vite \+ React/i)
+  expect(headingElement).toBeInTheDocument()
+})


### PR DESCRIPTION
Add unit tests using Jest.

* **package.json**
  - Add `jest` and `@types/jest` to `devDependencies`
  - Add `test` script to run `jest`
* **jest.config.js**
  - Export a configuration object for Jest
  - Set `testEnvironment` to `jsdom`
  - Set `transform` to handle TypeScript files using `ts-jest`
* **src/App.test.tsx**
  - Import `render` and `screen` from `@testing-library/react`
  - Import `App` component
  - Write a test to check if the "Vite + React" heading is rendered

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KevinYang2229/Lint/pull/2?shareId=e42aad9a-7262-4a94-8116-6983f9e24985).